### PR TITLE
Vuetify の dark モードを解除

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -56,7 +56,7 @@ export default {
   vuetify: {
     customVariables: ['~/assets/variables.scss'],
     theme: {
-      dark: true,
+      dark: false,
       themes: {
         dark: {
           primary: colors.blue.darken2,


### PR DESCRIPTION
## 概要
 - Vuetify は標準でダークモードが採用されているため、この設定を OFF に変更した。

## イメージ
![ScreenShot 2020-12-28 14 38 58](https://user-images.githubusercontent.com/10157007/103192043-96a05780-491a-11eb-870e-be033ea68469.png)
