### PR TITLE
レイアウトを調整し、ヘッダーに必要な情報のみ残すように修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,7 +18,7 @@
 export default {
   data() {
     return {
-      title: 'Vuetify.js',
+      title: 'ロジねこビュー',
     }
   },
 }


### PR DESCRIPTION
## 概要
 - `layouts/default.vue` から不要な記述を削除
 - ヘッダーのデザインを [Vuetify のドキュメント](https://vuetifyjs.com/ja/components/app-bars/) を見ながら調整
 - ヘッダーのタイトルにアプリ名を表示

## イメージ
|Before|After|
|---|---|
|![ScreenShot 2020-12-28 14 56 30](https://user-images.githubusercontent.com/10157007/103192689-e3852d80-491c-11eb-8d3f-b7739fe1d5e0.png)|![ScreenShot 2020-12-28 14 55 40](https://user-images.githubusercontent.com/10157007/103192645-c51f3200-491c-11eb-8a1b-352da32d86fa.png)|
