### PR TITLE
トップページで、ねこのデータの配列を取得するように調整

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,15 +4,20 @@
 
 <script>
 export default {
+  data() {
+    return {
+      cats: [],
+    }
+  },
   async created() {
     try {
       const response = await this.$axios.get(
         'https://jsondata.okiba.me/v1/json/7lV2J201227155106'
       )
-      console.log(response)
+      this.cats = response.data.results
     } catch (err) {
       const res = err.response
-      console.log(res)
+      alert(res)
     }
   },
 }


### PR DESCRIPTION
## 概要
 - トップページ(pages/index.vue) で、指定された API （ https://jsondata.okiba.me/v1/json/7lV2J201227155106 ）から JSON を取得し、data の cats に代入するロジックを実装
