### PR TITLE
ロジねこのデータを取得する API を準備

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,7 +23,7 @@ export default {
   async created() {
     try {
       const response = await this.$axios.get(
-        'https://jsondata.okiba.me/v1/json/7lV2J201227155106'
+        'https://livlog.xyz/webapi/cats.json'
       )
       this.cats = response.data.results
     } catch (err) {


### PR DESCRIPTION
## 概要
 - 独自のレスポンスを準備できるAPI作成サービスがサ終していたので、もとの提供されている endpoint に修正

## 懸念点
 - API のレスポンスデータが多すぎるので、本当は10件程度に制限したい